### PR TITLE
update http to ^1.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^1.0.0
-  http: ^0.13.4
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
it'll not cause version mismatch issue with many packages as many packages require 1.1.0 of http. its working fine with http ^1.1.0