### PR TITLE
fix: shorten generated random seed length

### DIFF
--- a/lib/dice_bear.dart
+++ b/lib/dice_bear.dart
@@ -880,7 +880,7 @@ void _validateRangeArray({
   }
 }
 
-String _randomString({int length = 200}) {
+String _randomString({int length = 20}) {
   const chars =
       'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
   final random = Random();


### PR DESCRIPTION
Reduces the default length of generated random seeds from 200 to 20 characters to keep URLs clean and compact. Closes #45