### PR TITLE
fix: align backgroundRotation validation with DiceBear v9 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.3
+* Fixed `backgroundRotation` validation
+
 ## 1.0.2
 * Reduces the generated random seed length from 200 to 16 characters
 

--- a/lib/dice_bear.dart
+++ b/lib/dice_bear.dart
@@ -370,7 +370,7 @@ class DiceBearCoreOptions {
 
       for (final value in backgroundRotation!) {
         _checkRange(
-            name: 'backgroundRotation', value: value, min: 0, max: 360);
+            name: 'backgroundRotation', value: value, min: -360, max: 360);
       }
     }
 

--- a/lib/dice_bear.dart
+++ b/lib/dice_bear.dart
@@ -360,17 +360,17 @@ class DiceBearCoreOptions {
     _checkRange(name: 'translateY', value: translateY, min: -100, max: 100);
 
     if (backgroundRotation != null) {
-      if (backgroundRotation!.length != 2) {
+      if (backgroundRotation!.length < 1 || backgroundRotation!.length > 2) {
         throw ArgumentError.value(
           backgroundRotation,
           'backgroundRotation',
-          'must contain exactly 2 values [min, max]',
+          'must contain 1 or 2 values [min, max] or [value]',
         );
       }
 
       for (final value in backgroundRotation!) {
         _checkRange(
-            name: 'backgroundRotation', value: value, min: -360, max: 360);
+            name: 'backgroundRotation', value: value, min: 0, max: 360);
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dice_bear
 description: DiceBear API wrapper. DiceBear is an avatar library for designers and developers. Generate random avatar profile pictures!
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/ZaifSenpai/dice_bear
 
 environment:


### PR DESCRIPTION
According to the DiceBear v9 documentation, backgroundRotation can accept a range (min, max) or a single value. This PR updates the validation logic to allow 1 or 2 values and ensures rotation is within the 0-360 range.

Closes #44